### PR TITLE
Implement secure boot enforcement

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -166,6 +166,7 @@ static struct auth_info auth_info[] = {
 
 struct efi_variable *var_list;
 bool secure_boot_enable;
+bool secure_boot_enforce;
 bool auth_enforce = true;
 bool persistent = true;
 
@@ -2055,6 +2056,30 @@ void dispatch_command(uint8_t *comm_buf)
         DBG("Unknown command\n");
         break;
     };
+}
+
+bool
+check_secure_boot(void)
+{
+    EFI_STATUS status;
+    uint8_t *data;
+    UINTN data_len;
+    bool ret;
+
+    if (!secure_boot_enforce)
+        return true;
+
+    status = internal_get_variable(EFI_SECURE_BOOT_MODE_NAME,
+                                   sizeof(EFI_SECURE_BOOT_MODE_NAME),
+                                   &gEfiGlobalVariableGuid, &data, &data_len);
+
+    if (status != EFI_SUCCESS)
+        return false;
+
+    ret = data[0] ? true : false;
+    free(data);
+
+    return ret;
 }
 
 bool

--- a/handler.c
+++ b/handler.c
@@ -2073,11 +2073,15 @@ check_secure_boot(void)
                                    sizeof(EFI_SECURE_BOOT_MODE_NAME),
                                    &gEfiGlobalVariableGuid, &data, &data_len);
 
-    if (status != EFI_SUCCESS)
-        return false;
+    if (status != EFI_SUCCESS) {
+        ret = false;
+    } else  {
+        ret = data[0] ? true : false;
+        free(data);
+    }
 
-    ret = data[0] ? true : false;
-    free(data);
+    if (!ret)
+        db->sb_notify();
 
     return ret;
 }

--- a/include/handler.h
+++ b/include/handler.h
@@ -75,6 +75,7 @@ struct efi_variable {
 extern struct efi_variable *var_list;
 
 void dispatch_command(uint8_t *comm_buf);
+bool check_secure_boot(void);
 bool setup_crypto(void);
 bool setup_variables(void);
 bool setup_keys(void);
@@ -92,6 +93,7 @@ extern const uint8_t TCG2_PHYSICAL_PRESENCEFLAGSLOCK_NAME[];
 extern const size_t TCG2_PHYSICAL_PRESENCEFLAGSLOCK_NAME_SIZE;
 
 extern bool secure_boot_enable;
+extern bool secure_boot_enforce;
 extern bool auth_enforce;
 extern bool persistent;
 

--- a/varstored.c
+++ b/varstored.c
@@ -189,6 +189,17 @@ initialize_settings(struct xs_handle *xsh, domid_t domid)
 
     INFO("Secure boot enable: %s\n", secure_boot_enable ? "true" : "false");
 
+    if (secure_boot_enable) {
+        snprintf(path, sizeof(path),
+                 "/local/domain/%u/platform/secureboot-enforce", domid);
+        s = xs_read(xsh, XBT_NULL, path, NULL);
+
+        secure_boot_enforce = s && !strcmp(s, "true");
+        free(s);
+
+        INFO("Secure boot enforcing: %s\n", secure_boot_enforce ? "true" : "false");
+    }
+
     snprintf(path, sizeof(path),
              "/local/domain/%u/platform/auth-enforce", domid);
     s = xs_read(xsh, XBT_NULL, path, NULL);
@@ -530,6 +541,11 @@ varstored_initialize(domid_t domid)
                 goto err;
             }
         }
+    }
+
+    if (!check_secure_boot()) {
+        ERR("Secure boot is required, but isn't activated\n");
+        goto err;
     }
 
     free_auth_data();


### PR DESCRIPTION
Depending on a parameter, varstored aborts if secure_boot_enabled is activated, but no certificates are present.